### PR TITLE
codegen: vendor GLASS nested in grid:: namespace

### DIFF
--- a/helpers/_lin_alg_helpers.py
+++ b/helpers/_lin_alg_helpers.py
@@ -87,11 +87,16 @@ def gen_grid_linalg_backend_helpers(self):
     """
     glass_commit = _glass_commit()
     self.gen_add_func_doc("Vendored GLASS linear algebra helpers (SIMT only)")
-    self.gen_add_code_line("// Temporarily leave the generated namespace so GLASS keeps its public namespace.")
-    self.gen_add_end_control_flow()
+    # Vendor GLASS NESTED inside the generated namespace (e.g. `grid::glass`) rather
+    # than at global `glass::`. This keeps GRiD hermetic: a consumer can include its
+    # own (possibly newer) GLASS at the global `glass::` without an ODR clash against
+    # this pinned snapshot. Generated code refers to it as bare `glass::...`, which
+    # resolves to the nested namespace by ordinary lookup, so call sites need no
+    # qualification (and must NOT be globally qualified, which would escape to the
+    # consumer's global GLASS).
     self.gen_add_code_lines([
         "",
-        "// Vendored from GLASS at codegen time.",
+        "// Vendored from GLASS at codegen time (nested in this namespace).",
         "// Source repository: git@github.com:A2R-Lab/GLASS.git",
         "// Pinned commit: " + glass_commit,
         "namespace glass {",
@@ -102,7 +107,6 @@ def gen_grid_linalg_backend_helpers(self):
     self.gen_add_code_line("} // namespace glass")
     self.gen_add_code_line("")
 
-    self.gen_add_code_line("namespace " + self.file_namespace + " {", True)
     self.gen_add_func_doc("Linear algebra wrappers (SIMT GLASS)")
     self.gen_add_code_lines([
         "// SIMT-only linalg. cuBLASDx was removed in v2.0; the",
@@ -147,20 +151,20 @@ def gen_grid_linalg_backend_helpers(self):
         "template <typename T, int M, int N, int ROW_STRIDE>",
         "__device__ void grid_linalg_row_strided_gemv(const T *A, const T *x, T *y, T alpha, T beta, unsigned char *glass_nvidia_smem = nullptr) {",
         "    (void)glass_nvidia_smem;",
-        "    ::glass::row_strided_gemv<T, M, N, ROW_STRIDE>(A, x, y, alpha, beta);",
+        "    glass::row_strided_gemv<T, M, N, ROW_STRIDE>(A, x, y, alpha, beta);",
         "    __syncthreads();",
         "}",
         "",
         "template <typename T, int M, int N, int K, int A_RS, int B_RS>",
         "__device__ void grid_linalg_row_strided_gemm(const T *A, const T *B, T *C, T alpha, T beta, unsigned char *glass_nvidia_smem = nullptr) {",
         "    (void)glass_nvidia_smem;",
-        "    ::glass::row_strided_gemm<T, M, N, K, A_RS, B_RS>(A, B, C, alpha, beta);",
+        "    glass::row_strided_gemm<T, M, N, K, A_RS, B_RS>(A, B, C, alpha, beta);",
         "    __syncthreads();",
         "}",
         "",
         "template <typename T, int N, int S1, int S2>",
         "__device__ T grid_linalg_dot_strided(const T *vec1, const T *vec2) {",
-        "    return ::glass::dot_strided<T, N, S1, S2>(vec1, vec2);",
+        "    return glass::dot_strided<T, N, S1, S2>(vec1, vec2);",
         "}",
         "",
         "// Segmented (batched) row-strided GEMV: `segments` independent M x N GEMVs in one",
@@ -169,7 +173,7 @@ def gen_grid_linalg_backend_helpers(self):
         "template <typename T, int M, int N, int ROW_STRIDE = M, bool FUSE_SCALED_ADD = false>",
         "__device__ void grid_linalg_segmented_row_strided_gemv(unsigned int segments, const int *seg_a_off, const int *seg_x_off, const int *seg_y_off, const T *A, const T *x, T *y, T alpha, T beta, const int *seg_s_off = nullptr, const T *S = nullptr, const T *scalar = nullptr, unsigned char *glass_nvidia_smem = nullptr) {",
         "    (void)glass_nvidia_smem;",
-        "    ::glass::segmented_row_strided_gemv<T, M, N, ROW_STRIDE, FUSE_SCALED_ADD>(segments, seg_a_off, seg_x_off, seg_y_off, A, x, y, alpha, beta, seg_s_off, S, scalar);",
+        "    glass::segmented_row_strided_gemv<T, M, N, ROW_STRIDE, FUSE_SCALED_ADD>(segments, seg_a_off, seg_x_off, seg_y_off, A, x, y, alpha, beta, seg_s_off, S, scalar);",
         "    __syncthreads();",
         "}",
         "",
@@ -178,7 +182,7 @@ def gen_grid_linalg_backend_helpers(self):
         "template <typename T, int DIM = 4>",
         "__device__ void grid_linalg_indexed_batched_gemm(unsigned int pairs, const int *a_idx, const int *b_idx, const int *c_idx, const T *A_base, const T *B_base, T *C_base, unsigned char *glass_nvidia_smem = nullptr) {",
         "    (void)glass_nvidia_smem;",
-        "    ::glass::indexed_batched_gemm<T, DIM>(pairs, a_idx, b_idx, c_idx, A_base, B_base, C_base);",
+        "    glass::indexed_batched_gemm<T, DIM>(pairs, a_idx, b_idx, c_idx, A_base, B_base, C_base);",
         "    __syncthreads();",
         "}",
         "",
@@ -189,7 +193,7 @@ def gen_grid_linalg_backend_helpers(self):
         "// T of s_scratch. NOT a drop-in for grid_linalg_dot_strided (that one is per-thread).",
         "template <typename T, int N, int SX = 1, int SY = 1>",
         "__device__ void grid_linalg_dot_strided_coalesced(const T *x, const T *y, T *out, T *s_scratch) {",
-        "    ::glass::dot_strided_coalesced<T, N, SX, SY>(x, y, out, s_scratch);",
+        "    glass::dot_strided_coalesced<T, N, SX, SY>(x, y, out, s_scratch);",
         "    __syncthreads();",
         "}",
         ""

--- a/helpers/_spatial_algebra_helpers.py
+++ b/helpers/_spatial_algebra_helpers.py
@@ -158,7 +158,7 @@ def gen_spatial_algebra_helpers(self):
             self.gen_add_code_line("T dot_prod(const T *vec1, T *vec2) {", True)
         else:
             self.gen_add_code_line("T dot_prod(T *vec1, T *vec2) {", True)
-        self.gen_add_code_line("return ::glass::dot_strided<T, N, S1, S2>(vec1, vec2);")
+        self.gen_add_code_line("return glass::dot_strided<T, N, S1, S2>(vec1, vec2);")
         self.gen_add_end_function()
 
     # Then the motion vector matrix cross product operations


### PR DESCRIPTION
## Summary

Vendor GLASS **nested inside the generated `grid` namespace** (as `grid::glass`) instead of at global
`glass::` scope. The generated header becomes hermetic: a consumer that also includes GLASS directly (e.g. a
newer version, or to use a sub-namespace GRiD doesn't vendor) no longer hits an ODR/redefinition clash, and
can't silently bind GRiD's pinned-old GLASS.

Codegen change only — 26 lines across two helpers in `GRiDCodeGenerator`
(`helpers/_lin_alg_helpers.py`, `helpers/_spatial_algebra_helpers.py`):
- `gen_grid_linalg_backend_helpers` no longer closes the `grid` namespace before the vendored block and
  reopens it after — the `namespace glass { ... }` block now nests inside the already-open `grid` namespace
  (dropping one dedent + one indent keeps the braces balanced).
- The ~10 generated wrapper call sites are normalized from globally-qualified `::glass::` to bare `glass::`,
  which now resolves to `grid::glass` by ordinary lookup (no per-call qualification needed). The vendored
  GLASS bodies are already namespace-clean (zero self-`::glass::`), so the nesting is safe.

## Behavior change (intentional, worth flagging for reviewers)

GRiD **no longer exposes GLASS at global `glass::` scope.** Any downstream that depended on reaching the
vendored GLASS globally must now depend on GLASS explicitly. This is the point — it removes a silent
version-skew footgun. (A static scan of GRiD + grid_rbd found no such consumer.) A future
`-DGRID_NO_VENDOR_GLASS` BYO-GLASS flag could be added, but is intentionally **not** the default (it would
lose the hermetic guarantee).

## Validation

- **Codegen diff (behavior-preservation proof):** regenerated headers for iiwa14 (fixed-base) and go2
  (floating-base) at this commit vs its parent. Whitespace-insensitive, the *entire* diff is exactly: the
  removed namespace-close/reopen + comment text + the `::glass::`→`glass::` normalization. **Zero substantive
  code differences** — no algorithm body, signature, or numeric value changed; the generated CUDA is
  functionally identical modulo namespace nesting.
- **Compile + on-device run:** the nested-`grid::glass` header compiles with nvcc on sm_120 (CUDA 13.2) —
  iiwa14 (fixed) compiles **and runs** the print kernel correctly; go2 (floating) compiles clean.
- **Consumer compile:** the `grid_rbd` bindings wrapper (`wrapper_template.cu`, the robot-agnostic C ABI)
  compiles clean against the regenerated nested-glass header — confirming no consumer relied on the old
  global-`glass::` vendoring.
- A two-translation-unit test (`#include` a GRiD header + an external GLASS that carries a `glass::warp`
  sub-namespace) compiles clean with no ODR clash — `glass::warp::*` binds the external copy, `grid::glass::*`
  the vendored copy.

## Motivation

Enables consumers (here, the HJCD-IK IK solver) to include both the generated GRiD header and a directly-pinned
external GLASS in the same translation unit.